### PR TITLE
Allow no case sensitive for extension in the fname

### DIFF
--- a/bin/dxt2png.js
+++ b/bin/dxt2png.js
@@ -20,7 +20,7 @@ program
 
 if (program.directory) {
   let dirLocation = path.resolve(process.cwd());
-  let files = fs.readdirSync(dirLocation).filter(file => file.endsWith('.dxt'));
+  let files = fs.readdirSync(dirLocation).filter(file => file.toLowerCase().endsWith('.dxt'));
 
   if (files.length == 0) {
     console.log('no .dxt files found!');


### PR DESCRIPTION
Fixed where upper case DXT files are not being converted. (It exists in some KO clients.)

_Btw thanks for such great utiliy script. It helped me converting dxts into pngs._